### PR TITLE
Simpler base calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "ew_encoder"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "include-lines",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ew_encoder"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/readme.markdown
+++ b/readme.markdown
@@ -9,11 +9,9 @@ Running `cargo run --bin ew_encoder` prints a little demo:
 If we have a 128-bit key of 
 [64, 65, 86, 20, 87, 170, 254, 198, 217, 225, 243, 255, 198, 106, 21, 11]
 We first convert it into base-2642247:
-[114397, 691184, 2124657, 1576564, 1359289, 156987]
+[114397, 119199, 503890, 847975, 2387380, 1468640]
 Finally, we convert this into 6 emoji-word pairs:
-👍 anxieties 🧢 differences 🎧 servants 🎲 northernmost ⏰ least 🎷 asserting
-MAX key in base-2642247 is:
-[2642240, 1843709, 2421924, 2104602, 1961804, 2523288]
+👍 anxieties 🍑 appealed 🍦 conscience 🍦 environments 🐼 territorial 🔥 medicines
 ```
 
 ## Why use lists of exactly 203 emoji and 13016 words?
@@ -68,23 +66,6 @@ Now we get (a) option for 6 pairs rather than 8 and (b) the word list length and
 I believe this process is the most interesting part of this project.
 
 For the rest of this project, I picked the 13,016 words + 203 emoji pair.
-
-## Calculating what "base" to encode each "digit" in 
-This function also involved some creative information theory work.
-
-```rust
-pub fn calculate_base() -> u128 {
-    (202 + 203 * 13015) as u128
-}
-```
-I adapted the formula on page 5 of this paper on the ["drunken bishop"](http://dirk-loss.de/sshvis/drunken_bishop.pdf). 
-
-In general form, I think it's:
-```
-word_list_1_length - 1 + word_list_1_length * (word_list_2_length - 1) 
-```
-
-I think what we're doing here is creating a formula such that two numbers can be represented by one larger number, but being a little smarter than just multiplying them together. But I could be wrong!
 
 ## A crude measure of success
 The fact that when we use this process to encode the highest possible 128-bit value, the first word used is the last word listed on the word list. In other words, we couldn't use fewer words than 13,016 to encode all possible 128-bit values.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub fn get_x_and_y_from_part_of_key(part_of_key: usize) -> (usize, usize) {
 /// I adapted the formula on page 5 of this paper:
 /// http://dirk-loss.de/sshvis/drunken_bishop.pdf
 pub fn calculate_base() -> u128 {
-    (202 + 203 * 13015) as u128 // 7 low
+    (203 * 13016) as u128 // 7 low
 }
 
 /// Encodes a 128 u8 array into 6 "digits" of base 2642247.
@@ -91,7 +91,7 @@ fn can_encode_a_sample_key() {
 
     assert_eq!(
         visual_fingerprint,
-        "👍 anxieties 🧢 differences 🎧 servants 🎲 northernmost ⏰ least 🎷 asserting"
+        "👍 anxieties 🍑 appealed 🍦 conscience 🍦 environments 🐼 territorial 🔥 medicines"
     );
 }
 
@@ -101,7 +101,7 @@ fn can_encode_max_u128() {
     let visual_fingerprint = key_to_emoji_and_words(max_key_possible);
     assert_eq!(
         visual_fingerprint,
-        "🚕 zoo 🎮 properly 🔊 tong 👀 seeks ⛺ relief 🛟 uttered"
+        "🙏 zoo 👷 properly 🛁 cap 🦆 dealers 💰 brass 🌲 scope"
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,9 @@ pub fn get_x_and_y_from_part_of_key(part_of_key: usize) -> (usize, usize) {
     (x, y)
 }
 
-/// Calculate what "base" to encode in.
-/// I adapted the formula on page 5 of this paper:
-/// http://dirk-loss.de/sshvis/drunken_bishop.pdf
+/// Calculate what "base" to encode in. Just the length of first list * length of second list
 pub fn calculate_base() -> u128 {
-    (203 * 13016) as u128 // 7 low
+    (203 * 13016) as u128
 }
 
 /// Encodes a 128 u8 array into 6 "digits" of base 2642247.

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,4 +43,9 @@ fn main() {
         base,
         to_custom_base(max_key)
     );
+    let visual_fingerprint = key_to_emoji_and_words(max_key);
+    println!(
+        "Encoding this to emoji+word pairs, we get:\n{}",
+        visual_fingerprint
+    );
 }


### PR DESCRIPTION
@westonal caught an off-by-one error that my convoluted `calculate_base` function introduced (maybe a concept known as "the drunken bishop" wasn't right in this case after all!).

Now we have the much simpler and sensible: 
```rust
/// Calculate what "base" to encode in. Just the length of first list * length of second list
pub fn calculate_base() -> u128 {
    (203 * 13016) as u128
}
```

## Lingering question

I guess I still don't have a programmatic test to measure the efficiency of a given base (or scheme).